### PR TITLE
Chat read persistence: ensure delivery_status=2 is persisted/returned…

### DIFF
--- a/backend/communications/views.py
+++ b/backend/communications/views.py
@@ -429,6 +429,13 @@ class ConversationViewSet(viewsets.ModelViewSet):
                     pass
         except Exception:
             pass
+        # Consistency guard: ensure any message already marked read_at has delivery_status=2
+        try:
+            conv.messages.filter(read_at__isnull=False, delivery_status__lt=2).update(
+                delivery_status=dj_models.Value(2)
+            )
+        except Exception:
+            pass
         since_id = request.query_params.get('since_id')
         before = request.query_params.get('before')
         try:

--- a/frontend/src/app/conversation/[id]/page.tsx
+++ b/frontend/src/app/conversation/[id]/page.tsx
@@ -108,10 +108,17 @@ export default function ConversationPage() {
         // Initialize last read marker for my messages from persisted status
         try {
           const myUser = meInfo?.username;
-          const maxRead = ordered
+          const maxReadPersisted = ordered
             .filter((m:any) => m?.sender?.username === myUser && ((m?.delivery_status ?? 0) >= 2 || m?.status === 'read'))
             .reduce((acc:number, m:any) => Math.max(acc, Number(m.id)||0), 0);
-          const initial = maxRead || 0;
+          // Also consider sessionStorage fallback (from live WS events) to bridge any short API lag
+          let stored = 0;
+          try {
+            const key = `conv_last_read_other_${convId}_${myUser || ''}`;
+            const raw = typeof window !== 'undefined' ? window.sessionStorage.getItem(key) : null;
+            stored = raw ? Number(raw) || 0 : 0;
+          } catch {}
+          const initial = Math.max(maxReadPersisted || 0, stored || 0);
           if (initial > 0) setLastReadByOther(initial);
         } catch {}
         // Scroll to bottom


### PR DESCRIPTION
… and UI remains blue after refresh

- WS: In ConversationConsumer, compute IDs before read update and broadcast per-message status (cap 300) so senders upgrade to blue reliably.
- API: In ConversationViewSet.messages, add consistency guard to set delivery_status=2 where read_at is set, ensuring GET returns 2 persistently even after refresh.
- FE: On initial load, merge persisted delivery_status with sessionStorage last-read marker to keep blue ticks stable across reloads; do not downgrade locally.